### PR TITLE
Changed output of node fields for response sets and fixed formatting

### DIFF
--- a/nap_platformdata_generator.pl
+++ b/nap_platformdata_generator.pl
@@ -77,10 +77,10 @@ $school[$i] = {LOCALID => 'x7286' . $i , ACARAID =>  21212 + $i, GUID => lc guid
 }
 
 open F, ">sif.xml";
-print F "<sif>\n";
+print F "<sif>";
 foreach $s (@school) {
 printf F qq{
-<SchoolInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RefId="%s" xmlns="http://www.sifassociation.org/datamodel/au/3.4">
+  <SchoolInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RefId="%s" xmlns="http://www.sifassociation.org/datamodel/au/3.4">
   <LocalId>%s</LocalId>
   <StateProvinceId xsi:nil="true" />
   <CommonwealthId xsi:nil="true" />
@@ -119,7 +119,8 @@ printf F qq{
   <SchoolGroupList xsi:nil="true" />
   <SIF_Metadata xsi:nil="true" />
   <SIF_ExtendedElements xsi:nil="true" />
-</SchoolInfo> }, 
+</SchoolInfo>
+}, 
 $$s{GUID},
 $$s{LOCALID},
 $$s{ACARAID},
@@ -314,8 +315,7 @@ foreach $domain (@domainsLC_tests) {
     $domain_out =~ s/_alt//;
     next if $domain_out eq 'Writing' and $testlevel == 3;
     
-    printf F qq{
-<NAPTest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RefId="%s" xmlns="http://www.sifassociation.org/datamodel/au/3.4">
+    printf F qq{<NAPTest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RefId="%s" xmlns="http://www.sifassociation.org/datamodel/au/3.4">
   <TestContent>
     <NAPTestLocalId>%s</NAPTestLocalId>
     <TestName>%s Year %s</TestName>
@@ -518,8 +518,7 @@ printf F qq{
 %s  </TestItemList>
   <SIF_Metadata xsi:nil="true" />
   <SIF_ExtendedElements xsi:nil="true" />
-</NAPTestlet>
-},
+</NAPTestlet>},
 $refid,
 $naptests{$domain}{$testlevel}{GUID},
 $naptests{$domain}{$testlevel}{LOCALID},
@@ -544,7 +543,7 @@ $items,
 push @{$naptestlet{$domain}{$testlevel}{$node}}, {GUID => $refid, LOCALID => $localid, NAME => $testletname, SUBSCORE => $testletsubscore, RULES => $testletrulelist};
 
 }}}}
-print F "</NAPTestlets>\n";
+print F "\n</NAPTestlets>\n";
 
 
 printf F qq{<NAPTestItems xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sifassociation.org/datamodel/au/3.4">};
@@ -1012,13 +1011,12 @@ printf F qq{
   </TestItemContent>
   <SIF_Metadata xsi:nil="true" />
   <SIF_ExtendedElements xsi:nil="true" />
-</NAPTestItem>
-}, $refid, $localid, $itemlist{$refid}{XML};
-    
-    
+</NAPTestItem>},
+$refid,
+$localid,
+$itemlist{$refid}{XML};
 }
-
-print F "</NAPTestItems>\n";
+print F "\n</NAPTestItems>\n";
 
 foreach $school (sort keys %students) {
 foreach $yearlevel (sort keys %{$students{$school}}) {
@@ -1036,8 +1034,7 @@ foreach $domain (sort keys %naptests) {
     my @adjustments = adjustments($domain_out);
     $adjustment_link{$$student{GUID}}{$domain_out} = dclone(\@adjustments);
 
-printf F qq{
-<NAPEventStudentLink xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RefId="%s" xmlns="http://www.sifassociation.org/datamodel/au/3.4">
+printf F qq{<NAPEventStudentLink xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RefId="%s" xmlns="http://www.sifassociation.org/datamodel/au/3.4">
   <StudentPersonalRefId>%s</StudentPersonalRefId>
   <PlatformStudentIdentifier>%s</PlatformStudentIdentifier>
   <SchoolInfoRefId>%s</SchoolInfoRefId>
@@ -1091,8 +1088,7 @@ foreach $domain (sort keys %naptests) {
     $refid = lc guid_as_string();
 #printf STDERR "%s\t%s\t%s\n", $school, $domain, $yearlevel;
 
-printf F qq{
-<NAPTestScoreSummary xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RefId="%s" xmlns="http://www.sifassociation.org/datamodel/au/3.4">
+printf F qq{<NAPTestScoreSummary xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" RefId="%s" xmlns="http://www.sifassociation.org/datamodel/au/3.4">
   <SchoolInfoRefId>%s</SchoolInfoRefId>
   <SchoolACARAId>%s</SchoolACARAId>
   <NAPTestRefId>%s</NAPTestRefId>
@@ -1104,7 +1100,8 @@ printf F qq{
   <DomainBottomNational60Percent>%.2d</DomainBottomNational60Percent>
   <SIF_Metadata xsi:nil="true" />
   <SIF_ExtendedElements xsi:nil="true" />
-</NAPTestScoreSummary>},
+</NAPTestScoreSummary>
+},
 $refid,
 $school[$school]{GUID},
 $school[$school]{ACARAID},
@@ -1122,7 +1119,7 @@ rand(200)+$yearlevel_averages{$yearlevel}-20,
 
 %x = ();
 
-printf F qq{\n<NAPStudentResponseSets xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sifassociation.org/datamodel/au/3.4">};
+printf F qq{<NAPStudentResponseSets xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sifassociation.org/datamodel/au/3.4">};
 foreach $d (@domainsLC_tests) {
 foreach $e (@{$events{$d}}) {
     next if $$e{PARTICIPATION} eq 'A';
@@ -1301,15 +1298,13 @@ $items,
     domain_band($test_score, $max_score, $$e{YEARLEVEL}),
     if ($$e{PARTICIPATION} eq 'P' );
     printf F qq{
-    <TestletList>
-%s
+    <TestletList>%s
     </TestletList> },
     $testlets if ($$e{PARTICIPATION} eq 'P' || $$e{PARTICIPATION} eq 'S') ;
     print F qq{
   <SIF_Metadata xsi:nil="true" />
   <SIF_ExtendedElements xsi:nil="true" />
-</NAPStudentResponseSet>    
-}
+</NAPStudentResponseSet>}
 
 }}
 print F "</NAPStudentResponseSets>\n";
@@ -1378,8 +1373,7 @@ foreach $testlet (@{$naptestlet{$domain}{$testlevel}{$node}}) {
 
 
 
-printf F qq{
-    <Testlet>
+printf F qq{<Testlet>
       <NAPTestletRefId>%s</NAPTestletRefId>
       <TestletContent>
         <NAPTestletLocalId>%s</NAPTestletLocalId>
@@ -1863,5 +1857,3 @@ sub subdomain($$){
     return 'Spelling' if $domain eq 'Spelling';
     return '??';
 }
-
-

--- a/nap_platformdata_generator.pl
+++ b/nap_platformdata_generator.pl
@@ -1252,7 +1252,7 @@ $items,
     rand() > .95 ? 'true' : 'false' ,
     ($$e{DOMAIN} eq 'Writing' ? 
       qq{<PathTakenForDomain xsi:nil="true" />\n    <ParallelTest xsi:nil="true" />} : 
-      sprintf("<PathTakenForDomain>%s</PathTakenForDomain>\n    <ParallelTest>%s</ParallelTest>",$nodepath, $testletpath)),
+      sprintf("<PathTakenForDomain>%s</PathTakenForDomain>\n    <ParallelTest>%s</ParallelTest>",check_path_sep($nodepath), check_path_sep($testletpath))),
     $$e{STUDENTGUID},
     $$e{PSI},
     $$e{NAPTESTGUID},
@@ -1721,6 +1721,18 @@ sub print_node_path($) {
     # return qq{<Node xsi:nil="true" />} if $ret eq 'Blank';
     $ret =~ s/lc//g;
     return $ret;
+}
+
+sub check_path_sep() {
+	my ($ret) = @_;
+	if (length($ret) == 3) {
+		return substr($ret,1,2);
+	} elsif (substr($ret,0,1) eq '0') {
+		return substr($ret,2);
+	}
+	else {
+		return @_;
+	}
 }
 
 sub itempertestlet($$) {


### PR DESCRIPTION
Made it so PathTakenForDomain wont start with ':' and c wont start with '0:'